### PR TITLE
update: fix url field parse error

### DIFF
--- a/src/mongoengine_jsonschema/mixin.py
+++ b/src/mongoengine_jsonschema/mixin.py
@@ -171,7 +171,8 @@ class JsonSchemaMixin:
                 field_dict[v] = _val
 
         if 'pattern' in field_dict.keys() and field_dict['pattern'] is not None:
-            field_dict['pattern'] = field_dict['pattern'].pattern
+            if isinstance(field_dict['pattern'], re.Pattern):
+                field_dict['pattern'] = field_dict['pattern'].pattern
 
         if 'default' in field_dict.keys() and isinstance(getattr(field, 'default'), typing.Callable):
             field_dict['default'] = [] if type(field) == me.fields.ListField else {}

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -97,6 +97,7 @@ class ExampleDocument(me.Document, JsonSchemaMixin):
     string_field = me.StringField(min_length=1, max_length=2, choices=['1', '2', '3'], regex=r'.*', default='1')
     string_field_excluded = me.StringField(exclude_from_schema=True)
     URL_field = me.URLField()
+    URL_field2 = me.URLField(url_regex=r"^https?://[^\s/$.?#].[^\s]*$")
     UUID_field = me.UUIDField()
 
 


### PR DESCRIPTION
```python 
import mongoengine as me
from mongoengine_jsonschema.mixin import JsonSchemaMixin


class Test(me.Document, JsonSchemaMixin):
    name = me.StringField()
    age = me.IntField()
    uri = me.URLField()
    url = me.URLField(url_regex="http://.*")


Test.json_schema()
```
```sh
...
    field_dict['pattern'] = field_dict['pattern'].pattern
AttributeError: 'str' object has no attribute 'pattern'
```

```sh
➜ pip list | grep mongoengine 
mongoengine                       0.27.0
mongoengine-jsonschema            0.1.3

```
